### PR TITLE
AI-powered article scraping and improved geocoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Anthropic
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
 # Authentication
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=changeme

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "sassc-rails"
 gem 'geocoder'
 gem "nokogiri"
 gem 'dotenv-rails'
+gem "anthropic"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    anthropic (1.36.0)
+      cgi
+      connection_pool
     base64 (0.2.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
@@ -83,7 +86,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
     concurrent-ruby (1.3.4)
+    connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.3)
     date (3.3.4)
@@ -275,6 +280,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  anthropic
   bootsnap
   capybara
   debug

--- a/app/controllers/api/v1/geocode_controller.rb
+++ b/app/controllers/api/v1/geocode_controller.rb
@@ -9,6 +9,8 @@ class Api::V1::GeocodeController < ApplicationController
       return render json: { error: 'Query parameter is required' }, status: :bad_request
     end
 
+    query = normalize_intersection(query)
+
     unless query.match?(/tulsa|oklahoma|ok/i)
       query = "#{query}, Tulsa, OK"
     end
@@ -16,7 +18,7 @@ class Api::V1::GeocodeController < ApplicationController
     begin
       token = ENV['MAPBOX_ACCESS_TOKEN']
       encoded_query = URI.encode_www_form_component(query)
-      url = "https://api.mapbox.com/geocoding/v5/mapbox.places/#{encoded_query}.json?access_token=#{token}&proximity=-95.9928,36.1540&limit=5"
+      url = "https://api.mapbox.com/geocoding/v5/mapbox.places/#{encoded_query}.json?access_token=#{token}&proximity=-95.9928,36.1540&types=address&limit=5"
 
       uri = URI(url)
       http = Net::HTTP.new(uri.host, uri.port)
@@ -40,5 +42,11 @@ class Api::V1::GeocodeController < ApplicationController
       Rails.logger.error("Geocoding error: #{e.message}")
       render json: { error: 'Geocoding service unavailable' }, status: :service_unavailable
     end
+  end
+
+  private
+
+  def normalize_intersection(query)
+    query.gsub(/\s+(?:and|at|@)\s+/i, ' & ')
   end
 end

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -53,13 +53,14 @@ class IncidentsController < ApplicationController
       return render :scrape_new
     end
 
-    attributes = IncidentArticleScraper.scrape(url)
-    @article_text = attributes.delete(:article_text)
+    scraped = IncidentArticleScraper.scrape(url)
+    attributes = IncidentAiExtractor.extract(scraped[:article_text], publication_date: scraped[:publication_date])
+    attributes[:information_source] = scraped[:information_source]
+    @article_text = scraped[:article_text]
     @incident = Incident.new(attributes)
-    @incident.information_source ||= "News Article"
 
     render :new
-  rescue IncidentArticleScraper::ScrapeError => e
+  rescue IncidentArticleScraper::ScrapeError, IncidentAiExtractor::ExtractionError => e
     @scrape_error = e.message
     render :scrape_new
   end

--- a/app/services/incident_ai_extractor.rb
+++ b/app/services/incident_ai_extractor.rb
@@ -1,0 +1,71 @@
+class IncidentAiExtractor
+  class ExtractionError < StandardError; end
+
+  MODEL = "claude-haiku-4-5-20251001"
+
+  def self.extract(article_text, publication_date: nil)
+    new(article_text, publication_date).extract
+  end
+
+  def initialize(article_text, publication_date)
+    @article_text = article_text
+    @publication_date = publication_date
+  end
+
+  def extract
+    client = Anthropic::Client.new(api_key: ENV["ANTHROPIC_API_KEY"])
+    response = client.messages.create(
+      model: MODEL,
+      max_tokens: 512,
+      messages: [{ role: "user", content: prompt }]
+    )
+    parse_response(response.content.first.text)
+  rescue Anthropic::Errors::APIError => e
+    raise ExtractionError, "AI extraction failed: #{e.message}"
+  end
+
+  private
+
+  def prompt
+    pub_hint = @publication_date ? "The article was published on #{@publication_date.to_date}." : ""
+    <<~PROMPT
+      Extract structured data from this fatal traffic accident news article in NE Oklahoma/Tulsa area. #{pub_hint}
+
+      <article>
+      #{@article_text.truncate(8000)}
+      </article>
+
+      Return ONLY a valid JSON object with these fields:
+      {
+        "date_time": "ISO 8601 datetime of the incident (not publication date), or null if unknown",
+        "location_description": "specific street address or intersection from article, or null if not found",
+        "fatality_count": total integer deaths,
+        "pedestrian_count": integer pedestrians killed (0 if not mentioned),
+        "cyclist_count": integer cyclists killed (0 if not mentioned),
+        "motorcyclist_count": integer motorcyclists killed (0 if not mentioned),
+        "vehicle_occupant_count": integer vehicle occupants killed (0 if not mentioned),
+        "other_count": integer other fatalities not fitting above categories (0 if not mentioned),
+        "brief_description": "1-2 sentence factual summary of the incident"
+      }
+    PROMPT
+  end
+
+  def parse_response(text)
+    json = text.match(/\{.*\}/m)&.to_s
+    raise ExtractionError, "No JSON in AI response" unless json
+    data = JSON.parse(json)
+    {
+      date_time: data["date_time"] ? Time.zone.parse(data["date_time"]) : nil,
+      location_description: data["location_description"],
+      fatality_count: data["fatality_count"].to_i,
+      pedestrian_count: data["pedestrian_count"].to_i,
+      cyclist_count: data["cyclist_count"].to_i,
+      motorcyclist_count: data["motorcyclist_count"].to_i,
+      vehicle_occupant_count: data["vehicle_occupant_count"].to_i,
+      other_count: data["other_count"].to_i,
+      brief_description: data["brief_description"]
+    }
+  rescue JSON::ParserError => e
+    raise ExtractionError, "Could not parse AI response: #{e.message}"
+  end
+end

--- a/app/services/incident_article_scraper.rb
+++ b/app/services/incident_article_scraper.rb
@@ -4,19 +4,6 @@ require "nokogiri"
 class IncidentArticleScraper
   class ScrapeError < StandardError; end
 
-  WORD_NUMBER_MAP = {
-    "one" => 1,
-    "two" => 2,
-    "three" => 3,
-    "four" => 4,
-    "five" => 5,
-    "six" => 6,
-    "seven" => 7,
-    "eight" => 8,
-    "nine" => 9,
-    "ten" => 10
-  }.freeze
-
   def self.scrape(url)
     new(url).scrape
   end
@@ -31,12 +18,9 @@ class IncidentArticleScraper
     article_text = extract_article_text(doc)
 
     {
-      date_time: parse_time(metadata[:date]) || Time.current,
-      location_description: extract_location(article_text),
-      fatality_count: extract_fatalities(article_text),
-      brief_description: metadata[:description] || extract_summary(article_text),
-      information_source: @url,
-      article_text: article_text
+      article_text: article_text,
+      publication_date: parse_time(metadata[:date]),
+      information_source: @url
     }
   rescue OpenURI::HTTPError, SocketError, URI::InvalidURIError => e
     raise ScrapeError, "Unable to fetch article: #{e.message}"
@@ -51,10 +35,7 @@ class IncidentArticleScraper
   def extract_metadata(doc)
     json_ld = extract_json_ld(doc)
     {
-      title: json_ld[:headline] || meta_content(doc, "property", "og:title"),
-      description: json_ld[:description] || meta_content(doc, "name", "description") || meta_content(doc, "property", "og:description"),
-      date: json_ld[:date_published] || meta_content(doc, "property", "article:published_time"),
-      source: json_ld[:publisher] || meta_content(doc, "property", "og:site_name")
+      date: json_ld[:date_published] || meta_content(doc, "property", "article:published_time")
     }
   end
 
@@ -74,12 +55,7 @@ class IncidentArticleScraper
 
     return {} unless article
 
-    {
-      headline: article["headline"],
-      description: article["description"],
-      date_published: article["datePublished"],
-      publisher: article.dig("publisher", "name")
-    }
+    { date_published: article["datePublished"] }
   end
 
   def extract_article_text(doc)
@@ -100,33 +76,6 @@ class IncidentArticleScraper
     end
 
     doc.css("p").map { |p| p.text.squish }.join(" ")
-  end
-
-  def extract_fatalities(text)
-    return 0 if text.blank?
-
-    numeric_match = text.match(/\b(\d+)\b[^.]{0,80}\b(killed|dead|dies|died)\b/i)
-    return numeric_match[1].to_i if numeric_match
-
-    word_match = text.match(/\b(one|two|three|four|five|six|seven|eight|nine|ten)\b[^.]{0,80}\b(killed|dead|dies|died)\b/i)
-    return WORD_NUMBER_MAP[word_match[1].downcase] if word_match
-
-    0
-  end
-
-  def extract_location(text)
-    return nil if text.blank?
-
-    sentence = text.split(/[.!?]/).find { |line| line.match?(/\b(at|near|on|along|in)\b/i) }
-    return nil unless sentence
-
-    sentence.strip
-  end
-
-  def extract_summary(text)
-    return nil if text.blank?
-
-    text.strip[0, 300]
   end
 
   def scrub_article_node(node)
@@ -152,11 +101,5 @@ class IncidentArticleScraper
 
   def meta_content(doc, attr_key, attr_value)
     doc.at("meta[#{attr_key}='#{attr_value}']")&.[]("content")
-  end
-
-  def source_from_url
-    URI.parse(@url).host
-  rescue URI::InvalidURIError
-    nil
   end
 end


### PR DESCRIPTION
Replace regex-based incident extraction with Claude Haiku to populate all form fields including victim-type breakdowns. Fix Mapbox geocoding to return address-level results and normalize cross-street queries.